### PR TITLE
Channel Join / Leave | AutoJoin | Default Channels | Mute/Unmute per Channel | Message Hook

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -13,7 +13,7 @@
     
     <target name="compile" depends="init">
         <!-- Compile the java code -->
-        <javac srcdir="src" destdir="${build}" includeantruntime="false" target="1.6" source="1.6">
+        <javac srcdir="src" destdir="${build}" includeantruntime="false" target="1.6" source="1.6" debug="true">
             <classpath>
                 <pathelement location="${env.LIB}/bukkit.jar"/>
                 <pathelement location="${env.LIB}/craftbukkit.jar"/>

--- a/src/com/palmergames/bukkit/TownyChat/Chat.java
+++ b/src/com/palmergames/bukkit/TownyChat/Chat.java
@@ -227,5 +227,4 @@ public class Chat extends JavaPlugin {
 	public HeroicDeathForwarder getHeroicDeath() {
 		return heroicDeathListener;
 	}
-
 }

--- a/src/com/palmergames/bukkit/TownyChat/Chat.java
+++ b/src/com/palmergames/bukkit/TownyChat/Chat.java
@@ -77,8 +77,8 @@ public class Chat extends JavaPlugin {
 		getCommand("channel").setExecutor(new ChannelCommand(this));
 		getCommand("join").setExecutor(new JoinCommand(this));
 		getCommand("leave").setExecutor(new LeaveCommand(this));
-		getCommand("mute").setExecutor(new MuteCommand(this));
-		getCommand("unmute").setExecutor(new UnmuteCommand(this));
+		getCommand("chmute").setExecutor(new MuteCommand(this));
+		getCommand("chunmute").setExecutor(new UnmuteCommand(this));
 		getCommand("mutelist").setExecutor(new MuteListCommand(this));
 	}
 	

--- a/src/com/palmergames/bukkit/TownyChat/Chat.java
+++ b/src/com/palmergames/bukkit/TownyChat/Chat.java
@@ -10,7 +10,13 @@ import org.dynmap.DynmapAPI;
 
 import com.ensifera.animosity.craftirc.CraftIRC;
 import com.palmergames.bukkit.TownyChat.CraftIRCHandler;
+import com.palmergames.bukkit.TownyChat.Command.ChannelCommand;
+import com.palmergames.bukkit.TownyChat.Command.JoinCommand;
+import com.palmergames.bukkit.TownyChat.Command.LeaveCommand;
+import com.palmergames.bukkit.TownyChat.Command.MuteCommand;
+import com.palmergames.bukkit.TownyChat.Command.MuteListCommand;
 import com.palmergames.bukkit.TownyChat.Command.TownyChatCommand;
+import com.palmergames.bukkit.TownyChat.Command.UnmuteCommand;
 import com.palmergames.bukkit.TownyChat.channels.ChannelsHolder;
 import com.palmergames.bukkit.TownyChat.config.ConfigurationHandler;
 import com.palmergames.bukkit.TownyChat.listener.HeroicDeathForwarder;
@@ -68,7 +74,12 @@ public class Chat extends JavaPlugin {
 		}
 
 		getCommand("townychat").setExecutor(new TownyChatCommand(this));
-		
+		getCommand("channel").setExecutor(new ChannelCommand(this));
+		getCommand("join").setExecutor(new JoinCommand(this));
+		getCommand("leave").setExecutor(new LeaveCommand(this));
+		getCommand("mute").setExecutor(new MuteCommand(this));
+		getCommand("unmute").setExecutor(new UnmuteCommand(this));
+		getCommand("mutelist").setExecutor(new MuteListCommand(this));
 	}
 	
 	private boolean load() {

--- a/src/com/palmergames/bukkit/TownyChat/Command/ChannelCommand.java
+++ b/src/com/palmergames/bukkit/TownyChat/Command/ChannelCommand.java
@@ -33,11 +33,11 @@ public class ChannelCommand implements CommandExecutor {
 		}
 
 		if (args[0].equalsIgnoreCase("mute")) {
-			return plugin.getCommand("mute").getExecutor().onCommand(sender, cmd, label, args); 
+			return plugin.getCommand("chmute").getExecutor().onCommand(sender, cmd, label, args); 
 		}
 
 		if (args[0].equalsIgnoreCase("unmute")) {
-			return plugin.getCommand("unmute").getExecutor().onCommand(sender, cmd, label, args); 
+			return plugin.getCommand("chunmute").getExecutor().onCommand(sender, cmd, label, args); 
 		}
 
 		if (args[0].equalsIgnoreCase("mutelist")) {

--- a/src/com/palmergames/bukkit/TownyChat/Command/ChannelCommand.java
+++ b/src/com/palmergames/bukkit/TownyChat/Command/ChannelCommand.java
@@ -1,0 +1,49 @@
+package com.palmergames.bukkit.TownyChat.Command;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+import com.palmergames.bukkit.TownyChat.Chat;
+
+public class ChannelCommand implements CommandExecutor {
+
+	Chat plugin = null;
+
+	public ChannelCommand(Chat instance) {
+		this.plugin = instance;
+	}
+
+	@Override
+	public boolean onCommand(CommandSender sender, Command cmd, String label,	String[] args) {
+		if (!label.equalsIgnoreCase("ch") && !label.equalsIgnoreCase("channel")) {
+			return false;
+		}
+		
+		if (args.length == 0) {
+			return false;
+		}
+
+		if (args[0].equalsIgnoreCase("join")) {
+			return plugin.getCommand("join").getExecutor().onCommand(sender, cmd, label, args); 
+		}
+
+		if (args[0].equalsIgnoreCase("leave")) {
+			return plugin.getCommand("leave").getExecutor().onCommand(sender, cmd, label, args); 
+		}
+
+		if (args[0].equalsIgnoreCase("mute")) {
+			return plugin.getCommand("mute").getExecutor().onCommand(sender, cmd, label, args); 
+		}
+
+		if (args[0].equalsIgnoreCase("unmute")) {
+			return plugin.getCommand("unmute").getExecutor().onCommand(sender, cmd, label, args); 
+		}
+
+		if (args[0].equalsIgnoreCase("mutelist")) {
+			return plugin.getCommand("mutelist").getExecutor().onCommand(sender, cmd, label, args); 
+		}
+
+		return false;
+	}
+}

--- a/src/com/palmergames/bukkit/TownyChat/Command/JoinCommand.java
+++ b/src/com/palmergames/bukkit/TownyChat/Command/JoinCommand.java
@@ -58,7 +58,7 @@ public class JoinCommand implements CommandExecutor {
 		}
 		
 		if (chan == null) {
-			TownyMessaging.sendErrorMsg(sender, "[TownyChat] There is no channel called &f" + name);
+			TownyMessaging.sendErrorMsg(sender, "[TownyChat] There is no channel called " + Colors.White + name);
 			return true;
 		}
 				
@@ -69,16 +69,16 @@ public class JoinCommand implements CommandExecutor {
 		//     - player has channel permission
 		String joinPerm = chan.getPermission();
 		if ((joinPerm != null && (plugin.getTowny().isPermissions() && !TownyUniverse.getPermissionSource().has(player, joinPerm)))) {
-			TownyMessaging.sendErrorMsg(sender, "[TownyChat] You cannot join &f" + chan.getName());
+			TownyMessaging.sendErrorMsg(sender, "[TownyChat] You cannot join " + Colors.White + chan.getName());
 			return true;
 		}
 	
 		if (!chan.join(sender.getName())){
-			TownyMessaging.sendMsg(sender, "[TownyChat] You are already in &f" + chan.getName());
+			TownyMessaging.sendMsg(sender, "[TownyChat] You are already in " + Colors.White + chan.getName());
 			return true;
 		}
 		
-		TownyMessaging.sendMsg(sender, "[TownyChat] You joined &f" + chan.getName());
+		TownyMessaging.sendMsg(sender, "[TownyChat] You joined " + Colors.White + chan.getName());
 		return true;
 	}
 }

--- a/src/com/palmergames/bukkit/TownyChat/Command/JoinCommand.java
+++ b/src/com/palmergames/bukkit/TownyChat/Command/JoinCommand.java
@@ -1,0 +1,84 @@
+package com.palmergames.bukkit.TownyChat.Command;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import com.palmergames.bukkit.TownyChat.Chat;
+import com.palmergames.bukkit.TownyChat.channels.Channel;
+import com.palmergames.bukkit.towny.TownyMessaging;
+import com.palmergames.bukkit.towny.object.TownyUniverse;
+
+public class JoinCommand implements CommandExecutor {
+
+	Chat plugin = null;
+
+	public JoinCommand(Chat instance) {
+		this.plugin = instance;
+	}
+
+	@Override
+	public boolean onCommand(CommandSender sender, Command cmd, String label,	String[] args) {
+		// If not our command
+		if ((!label.equalsIgnoreCase("join") || args.length != 1) && 
+			(!label.equalsIgnoreCase("ch") || args.length != 2 || !args[0].equalsIgnoreCase("join"))) {
+			TownyMessaging.sendErrorMsg(sender, "[TownyChat] Error: Invalid command!");
+			return false;
+		}
+			
+		if (!(sender instanceof Player)) {
+			return false; // Don't think it can happen but ...
+		}
+
+		Player player = ((Player)sender);
+		
+		String name = null;
+		if (label.equalsIgnoreCase("leave")){
+			name = args[0];
+		} else {
+			name = args[1];
+		}
+		
+		Channel chan = plugin.getChannelsHandler().getChannel(name);
+
+		// If we can't find the channel by name, look up all the channel commands for an alias
+		if (chan == null) {
+			for(Channel chan2 : plugin.getChannelsHandler().getAllChannels().values()) {
+				for (String command : chan2.getCommands()) {
+					if (command.equalsIgnoreCase(name)) {
+						chan = chan2;
+						break;
+					}
+				}
+				if (chan != null) {
+					break;
+				}
+			}
+		}
+		
+		if (chan == null) {
+			TownyMessaging.sendErrorMsg(sender, "[TownyChat] There is no channel called &f" + name);
+			return true;
+		}
+				
+		// You can join if:
+		// - Towny doesn't recognize your permissions plugin
+		// - channel has no permission set OR  [by default they don't]
+		//   - channel has permission set AND:
+		//     - player has channel permission
+		String joinPerm = chan.getPermission();
+		if ((joinPerm != null && (plugin.getTowny().isPermissions() && !TownyUniverse.getPermissionSource().has(player, joinPerm)))) {
+			TownyMessaging.sendErrorMsg(sender, "[TownyChat] You cannot join &f" + chan.getName());
+			return true;
+		}
+	
+		if (!chan.join(sender.getName())){
+			TownyMessaging.sendMsg(sender, "[TownyChat] You are already in &f" + chan.getName());
+			return true;
+		}
+		
+		TownyMessaging.sendMsg(sender, "[TownyChat] You joined &f" + chan.getName());
+		return true;
+	}
+}

--- a/src/com/palmergames/bukkit/TownyChat/Command/JoinCommand.java
+++ b/src/com/palmergames/bukkit/TownyChat/Command/JoinCommand.java
@@ -34,7 +34,7 @@ public class JoinCommand implements CommandExecutor {
 		Player player = ((Player)sender);
 		
 		String name = null;
-		if (label.equalsIgnoreCase("leave")){
+		if (label.equalsIgnoreCase("join")){
 			name = args[0];
 		} else {
 			name = args[1];

--- a/src/com/palmergames/bukkit/TownyChat/Command/JoinCommand.java
+++ b/src/com/palmergames/bukkit/TownyChat/Command/JoinCommand.java
@@ -9,6 +9,7 @@ import com.palmergames.bukkit.TownyChat.Chat;
 import com.palmergames.bukkit.TownyChat.channels.Channel;
 import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.object.TownyUniverse;
+import com.palmergames.bukkit.util.Colors;
 
 public class JoinCommand implements CommandExecutor {
 

--- a/src/com/palmergames/bukkit/TownyChat/Command/LeaveCommand.java
+++ b/src/com/palmergames/bukkit/TownyChat/Command/LeaveCommand.java
@@ -91,9 +91,7 @@ public class LeaveCommand implements CommandExecutor {
 		if (plugin.getTowny().hasPlayerMode(player, chan.getName())) {
 			if (plugin.getChannelsHandler().getDefaultChannel() != null && plugin.getChannelsHandler().getDefaultChannel().isPresent(player.getName())) {
 				nextChannel = plugin.getChannelsHandler().getDefaultChannel();
-				if (TownyUtil.removePlayerMode(plugin.getTowny(), player, chan.getName(), false)) {
-					TownyUtil.addPlayerMode(plugin.getTowny(), player, nextChannel.getName(), true);
-				}
+				TownyUtil.removeAndSetPlayerMode(plugin.getTowny(), player, chan.getName(), nextChannel.getName(), true);
 			}
 		}
 		if (nextChannel == null) {

--- a/src/com/palmergames/bukkit/TownyChat/Command/LeaveCommand.java
+++ b/src/com/palmergames/bukkit/TownyChat/Command/LeaveCommand.java
@@ -1,0 +1,122 @@
+package com.palmergames.bukkit.TownyChat.Command;
+
+import java.util.logging.Level;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import com.palmergames.bukkit.TownyChat.Chat;
+import com.palmergames.bukkit.TownyChat.channels.Channel;
+import com.palmergames.bukkit.TownyChat.channels.channelTypes;
+import com.palmergames.bukkit.TownyChat.util.TownyUtil;
+import com.palmergames.bukkit.towny.TownyMessaging;
+import com.palmergames.bukkit.towny.object.TownyUniverse;
+import com.palmergames.bukkit.util.Colors;
+
+public class LeaveCommand implements CommandExecutor {
+
+	Chat plugin = null;
+
+	public LeaveCommand(Chat instance) {
+		this.plugin = instance;
+	}
+
+	@Override
+	public boolean onCommand(CommandSender sender, Command cmd, String label,	String[] args) {
+		// If not our command
+		if ((!label.equalsIgnoreCase("leave") || args.length != 1) && 
+			(!label.equalsIgnoreCase("ch") || args.length != 2 || !args[0].equalsIgnoreCase("leave"))) {
+			TownyMessaging.sendErrorMsg(sender, "[TownyChat] Error: Invalid command!");
+			return false;
+		}
+			
+		if (!(sender instanceof Player)) {
+			return false; // Don't think it can happen but ...
+		}
+
+		Player player = ((Player)sender);
+		
+		String name = null;
+		if (label.equalsIgnoreCase("leave")){
+			name = args[0];
+		} else {
+			name = args[1];
+		}
+		
+		Channel chan = plugin.getChannelsHandler().getChannel(name);
+
+		// If we can't find the channel by name, look up all the channel commands for an alias
+		if (chan == null) {
+			for(Channel chan2 : plugin.getChannelsHandler().getAllChannels().values()) {
+				for (String command : chan2.getCommands()) {
+					if (command.equalsIgnoreCase(name)) {
+						chan = chan2;
+						break;
+					}
+				}
+				if (chan != null) {
+					break;
+				}
+			}
+		}
+		
+		if (chan == null) {
+			TownyMessaging.sendErrorMsg(sender, "[TownyChat] There is no channel called " + Colors.White + name);
+			return true;
+		}
+
+		// You can leave if:
+		// - Towny recognizes your permissions plugin AND
+		// - channel has leaving permission set AND [by default they always do and you can provide your own permission name]
+		// - player has leaving permission set      [by default they don't]
+		String leavePerm = chan.getLeavePermission();
+		if ( leavePerm == null || 
+		   ( leavePerm != null && ( !plugin.getTowny().isPermissions() || 
+								  ( plugin.getTowny().isPermissions() && !TownyUniverse.getPermissionSource().has( player, leavePerm ) )))) {
+			TownyMessaging.sendErrorMsg(sender, "[TownyChat] You cannot leave " + Colors.White + chan.getName());
+			return true;
+		}
+
+		// If we fail you weren't in there to start with
+		if (!chan.leave(sender.getName())){
+			TownyMessaging.sendMsg(sender, "[TownyChat] You already left " + Colors.White + chan.getName());
+			return true;
+		}
+					
+		// Announce it
+		TownyMessaging.sendMsg(sender, "[TownyChat] You left " + Colors.White + chan.getName());
+
+		// Remove this channel from player modes
+		if (TownyUtil.removePlayerMode(plugin.getTowny(), player, chan.getName(), false)) {
+			
+		}
+		
+		Channel newchannel = null;
+		// Find us a new channel to speak on
+		newchannel = plugin.getChannelsHandler().getActiveChannel(player, channelTypes.GLOBAL);
+		if (newchannel == null) {
+			newchannel = plugin.getChannelsHandler().getActiveChannel(player, channelTypes.NATION);
+			if (newchannel == null) {
+				newchannel = plugin.getChannelsHandler().getActiveChannel(player, channelTypes.TOWN);
+				if (newchannel == null) {
+					newchannel = plugin.getChannelsHandler().getActiveChannel(player, channelTypes.DEFAULT);
+					if (newchannel == null) {
+						newchannel = plugin.getChannelsHandler().getActiveChannel(player, channelTypes.PRIVATE);
+					}
+				}
+			}
+		}
+
+		if (newchannel != null) {
+			TownyUtil.addPlayerMode(plugin.getTowny(), player, newchannel.getName(), true);
+			TownyMessaging.sendMsg(sender, "[TownyChat] You are now talking in " + Colors.White + newchannel.getName());
+		} else {
+			TownyMessaging.sendMsg(sender, "[TownyChat] You are now in blissful silence.");
+		}
+
+		return true;
+	}
+
+}

--- a/src/com/palmergames/bukkit/TownyChat/Command/LeaveCommand.java
+++ b/src/com/palmergames/bukkit/TownyChat/Command/LeaveCommand.java
@@ -86,7 +86,7 @@ public class LeaveCommand implements CommandExecutor {
 		// Announce it
 		TownyMessaging.sendMsg(sender, "[TownyChat] You left " + Colors.White + chan.getName());
 
-		
+		// Find what the next channel is if any
 		Channel nextChannel = null;
 		if (plugin.getTowny().hasPlayerMode(player, chan.getName())) {
 			if (plugin.getChannelsHandler().getDefaultChannel() != null && plugin.getChannelsHandler().getDefaultChannel().isPresent(player.getName())) {
@@ -99,7 +99,9 @@ public class LeaveCommand implements CommandExecutor {
 		if (nextChannel == null) {
 			nextChannel = plugin.getChannelsHandler().getActiveChannel(player, channelTypes.GLOBAL);
 		}
-		if (nextChannel != null) {
+		
+		// If the new channel is not us, announce it
+		if (nextChannel != null && !chan.getName().equalsIgnoreCase(nextChannel.getName())) {
 			TownyMessaging.sendMsg(sender, "[TownyChat] You are now talking in " + Colors.White + nextChannel.getName());
 		}
 		

--- a/src/com/palmergames/bukkit/TownyChat/Command/LeaveCommand.java
+++ b/src/com/palmergames/bukkit/TownyChat/Command/LeaveCommand.java
@@ -1,7 +1,5 @@
 package com.palmergames.bukkit.TownyChat.Command;
 
-import java.util.logging.Level;
-
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -88,35 +86,23 @@ public class LeaveCommand implements CommandExecutor {
 		// Announce it
 		TownyMessaging.sendMsg(sender, "[TownyChat] You left " + Colors.White + chan.getName());
 
-		// Remove this channel from player modes
-		if (TownyUtil.removePlayerMode(plugin.getTowny(), player, chan.getName(), false)) {
-			
-		}
 		
-		Channel newchannel = null;
-		// Find us a new channel to speak on
-		newchannel = plugin.getChannelsHandler().getActiveChannel(player, channelTypes.GLOBAL);
-		if (newchannel == null) {
-			newchannel = plugin.getChannelsHandler().getActiveChannel(player, channelTypes.NATION);
-			if (newchannel == null) {
-				newchannel = plugin.getChannelsHandler().getActiveChannel(player, channelTypes.TOWN);
-				if (newchannel == null) {
-					newchannel = plugin.getChannelsHandler().getActiveChannel(player, channelTypes.DEFAULT);
-					if (newchannel == null) {
-						newchannel = plugin.getChannelsHandler().getActiveChannel(player, channelTypes.PRIVATE);
-					}
+		Channel nextChannel = null;
+		if (plugin.getTowny().hasPlayerMode(player, chan.getName())) {
+			if (plugin.getChannelsHandler().getDefaultChannel() != null && plugin.getChannelsHandler().getDefaultChannel().isPresent(player.getName())) {
+				nextChannel = plugin.getChannelsHandler().getDefaultChannel();
+				if (TownyUtil.removePlayerMode(plugin.getTowny(), player, chan.getName(), false)) {
+					TownyUtil.addPlayerMode(plugin.getTowny(), player, nextChannel.getName(), true);
 				}
 			}
 		}
-
-		if (newchannel != null) {
-			TownyUtil.addPlayerMode(plugin.getTowny(), player, newchannel.getName(), true);
-			TownyMessaging.sendMsg(sender, "[TownyChat] You are now talking in " + Colors.White + newchannel.getName());
-		} else {
-			TownyMessaging.sendMsg(sender, "[TownyChat] You are now in blissful silence.");
+		if (nextChannel == null) {
+			nextChannel = plugin.getChannelsHandler().getActiveChannel(player, channelTypes.GLOBAL);
 		}
-
+		if (nextChannel != null) {
+			TownyMessaging.sendMsg(sender, "[TownyChat] You are now talking in " + Colors.White + nextChannel.getName());
+		}
+		
 		return true;
 	}
-
 }

--- a/src/com/palmergames/bukkit/TownyChat/Command/MuteCommand.java
+++ b/src/com/palmergames/bukkit/TownyChat/Command/MuteCommand.java
@@ -23,6 +23,7 @@ public class MuteCommand implements CommandExecutor {
 	public boolean onCommand(CommandSender sender, Command cmd, String label,	String[] args) {
 		// If not our command
 		if ((!label.equalsIgnoreCase("mute") || args.length != 2) && 
+			(!label.equalsIgnoreCase("chmute") || args.length != 2) && 
 			(!label.equalsIgnoreCase("ch") || args.length != 3 || !args[0].equalsIgnoreCase("mute"))) {
 			TownyMessaging.sendErrorMsg(sender, "[TownyChat] Error: Invalid command!");
 			return false;
@@ -34,14 +35,14 @@ public class MuteCommand implements CommandExecutor {
 
 		Player player = ((Player)sender);
 		
-		String name = null;
+		String channelName = null;
 		String mutee = null;
-		if (label.equalsIgnoreCase("mute")){
-			name = args[0];
+		if (label.equalsIgnoreCase("chmute") || label.equalsIgnoreCase("mute")){
+			channelName = args[0];
 			mutee = args[1];
 		} else {
-			name = args[1];
-			mutee = args[1];
+			channelName = args[1];
+			mutee = args[2];
 		}
 		
 		String mutePerm = plugin.getChannelsHandler().getMutePermission();
@@ -70,13 +71,13 @@ public class MuteCommand implements CommandExecutor {
 			return true;
 		}
 
-		Channel chan = plugin.getChannelsHandler().getChannel(name);
+		Channel chan = plugin.getChannelsHandler().getChannel(channelName);
 
 		// If we can't find the channel by name, look up all the channel commands for an alias
 		if (chan == null) {
 			for(Channel chan2 : plugin.getChannelsHandler().getAllChannels().values()) {
 				for (String command : chan2.getCommands()) {
-					if (command.equalsIgnoreCase(name)) {
+					if (command.equalsIgnoreCase(channelName)) {
 						chan = chan2;
 						break;
 					}
@@ -88,17 +89,17 @@ public class MuteCommand implements CommandExecutor {
 		}
 
 		if (chan == null) {
-			TownyMessaging.sendErrorMsg(sender, "[TownyChat] There is no channel called " + Colors.White + name);
+			TownyMessaging.sendErrorMsg(sender, "[TownyChat] There is no channel called " + Colors.White + channelName);
 			return true;
 		}
 
 		
-		if (!chan.mute(name)) {
+		if (!chan.mute(mutee)) {
 			TownyMessaging.sendMsg(sender, "[TownyChat] Player is already muted in "+ Colors.White + chan.getName());
 			return true;
 		}
 		
-		TownyMessaging.sendMsg(sender, "[TownyChat] " + Colors.White + name + Colors.Green +" is now muted in "+ Colors.White + chan.getName());
+		TownyMessaging.sendMsg(sender, "[TownyChat] " + Colors.White + mutee + Colors.Green +" is now muted in "+ Colors.White + chan.getName());
 		return true;
 	}
 }

--- a/src/com/palmergames/bukkit/TownyChat/Command/MuteCommand.java
+++ b/src/com/palmergames/bukkit/TownyChat/Command/MuteCommand.java
@@ -59,7 +59,7 @@ public class MuteCommand implements CommandExecutor {
 		mutee = muteePlayer.getName();
 		
 		if (plugin.getTowny().isPermissions() && TownyUniverse.getPermissionSource().isTownyAdmin(muteePlayer)){
-			TownyMessaging.sendErrorMsg(sender, "[TownyChat] You can't mute an Towny administrator.");
+			TownyMessaging.sendErrorMsg(sender, "[TownyChat] You can't mute a Towny administrator.");
 			return true;
 		}
 

--- a/src/com/palmergames/bukkit/TownyChat/Command/MuteCommand.java
+++ b/src/com/palmergames/bukkit/TownyChat/Command/MuteCommand.java
@@ -1,0 +1,104 @@
+package com.palmergames.bukkit.TownyChat.Command;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import com.palmergames.bukkit.TownyChat.Chat;
+import com.palmergames.bukkit.TownyChat.channels.Channel;
+import com.palmergames.bukkit.towny.TownyMessaging;
+import com.palmergames.bukkit.towny.object.TownyUniverse;
+import com.palmergames.bukkit.util.Colors;
+
+public class MuteCommand implements CommandExecutor {
+
+	Chat plugin = null;
+
+	public MuteCommand(Chat instance) {
+		this.plugin = instance;
+	}
+
+	@Override
+	public boolean onCommand(CommandSender sender, Command cmd, String label,	String[] args) {
+		// If not our command
+		if ((!label.equalsIgnoreCase("mute") || args.length != 2) && 
+			(!label.equalsIgnoreCase("ch") || args.length != 3 || !args[0].equalsIgnoreCase("mute"))) {
+			TownyMessaging.sendErrorMsg(sender, "[TownyChat] Error: Invalid command!");
+			return false;
+		}
+			
+		if (!(sender instanceof Player)) {
+			return false; // Don't think it can happen but ...
+		}
+
+		Player player = ((Player)sender);
+		
+		String name = null;
+		String mutee = null;
+		if (label.equalsIgnoreCase("mute")){
+			name = args[0];
+			mutee = args[1];
+		} else {
+			name = args[1];
+			mutee = args[1];
+		}
+		
+		String mutePerm = plugin.getChannelsHandler().getMutePermission();
+		if ((mutePerm == null) || (mutePerm != null && (plugin.getTowny().isPermissions() && !TownyUniverse.getPermissionSource().has(player, mutePerm)))) {
+			TownyMessaging.sendErrorMsg(sender, "[TownyChat] You don't have mute permissions");
+			return true;
+		}
+
+		Player muteePlayer = plugin.getServer().getPlayer(mutee);
+		if (muteePlayer == null) {
+			TownyMessaging.sendErrorMsg(sender, "[TownyChat] There are no online players with name " + Colors.White + mutee);
+			return true;
+		}
+
+		mutee = muteePlayer.getName();
+		
+		if (plugin.getTowny().isPermissions() && TownyUniverse.getPermissionSource().isTownyAdmin(muteePlayer)){
+			TownyMessaging.sendErrorMsg(sender, "[TownyChat] You can't mute an Towny administrator.");
+			return true;
+		}
+
+		String unmutePerm = plugin.getChannelsHandler().getUnmutePermission();
+		if ((mutePerm   != null && (plugin.getTowny().isPermissions() && TownyUniverse.getPermissionSource().has(muteePlayer, mutePerm))) ||
+			(unmutePerm != null && (plugin.getTowny().isPermissions() && TownyUniverse.getPermissionSource().has(muteePlayer, unmutePerm)))) {
+			TownyMessaging.sendErrorMsg(sender, "[TownyChat] You can't mute a chat moderator.");
+			return true;
+		}
+
+		Channel chan = plugin.getChannelsHandler().getChannel(name);
+
+		// If we can't find the channel by name, look up all the channel commands for an alias
+		if (chan == null) {
+			for(Channel chan2 : plugin.getChannelsHandler().getAllChannels().values()) {
+				for (String command : chan2.getCommands()) {
+					if (command.equalsIgnoreCase(name)) {
+						chan = chan2;
+						break;
+					}
+				}
+				if (chan != null) {
+					break;
+				}
+			}
+		}
+
+		if (chan == null) {
+			TownyMessaging.sendErrorMsg(sender, "[TownyChat] There is no channel called " + Colors.White + name);
+			return true;
+		}
+
+		
+		if (!chan.mute(name)) {
+			TownyMessaging.sendMsg(sender, "[TownyChat] Player is already muted in "+ Colors.White + chan.getName());
+			return true;
+		}
+		
+		TownyMessaging.sendMsg(sender, "[TownyChat] " + Colors.White + name + Colors.Green +" is now muted in "+ Colors.White + chan.getName());
+		return true;
+	}
+}

--- a/src/com/palmergames/bukkit/TownyChat/Command/MuteListCommand.java
+++ b/src/com/palmergames/bukkit/TownyChat/Command/MuteListCommand.java
@@ -83,15 +83,18 @@ public class MuteListCommand implements CommandExecutor {
 		
 		// TODO Support paging through this list
 		int count = 0;
-		Iterator<String> iter = chan.getMuteList().iterator();
-		boolean first = true;
 		String players = "";
-		while(iter.hasNext()) {
-			if (!first) {
-				players += Colors.Green + ", "+ Colors.White;
+
+		if (chan.hasMuteList()) {
+			Iterator<String> iter = chan.getMuteList().iterator();
+			boolean first = true;
+			while(iter.hasNext()) {
+				if (!first) {
+					players += Colors.Green + ", "+ Colors.White;
+				}
+				players += iter.next();
+				count++;
 			}
-			players += iter.next();
-			count++;
 		}
 
 		if (count == 0) {

--- a/src/com/palmergames/bukkit/TownyChat/Command/MuteListCommand.java
+++ b/src/com/palmergames/bukkit/TownyChat/Command/MuteListCommand.java
@@ -1,10 +1,6 @@
 package com.palmergames.bukkit.TownyChat.Command;
 
 import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-import java.util.logging.Level;
-
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -12,8 +8,6 @@ import org.bukkit.entity.Player;
 
 import com.palmergames.bukkit.TownyChat.Chat;
 import com.palmergames.bukkit.TownyChat.channels.Channel;
-import com.palmergames.bukkit.TownyChat.channels.channelTypes;
-import com.palmergames.bukkit.TownyChat.util.TownyUtil;
 import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.object.TownyUniverse;
 import com.palmergames.bukkit.util.Colors;

--- a/src/com/palmergames/bukkit/TownyChat/Command/MuteListCommand.java
+++ b/src/com/palmergames/bukkit/TownyChat/Command/MuteListCommand.java
@@ -1,0 +1,107 @@
+package com.palmergames.bukkit.TownyChat.Command;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import com.palmergames.bukkit.TownyChat.Chat;
+import com.palmergames.bukkit.TownyChat.channels.Channel;
+import com.palmergames.bukkit.TownyChat.channels.channelTypes;
+import com.palmergames.bukkit.TownyChat.util.TownyUtil;
+import com.palmergames.bukkit.towny.TownyMessaging;
+import com.palmergames.bukkit.towny.object.TownyUniverse;
+import com.palmergames.bukkit.util.Colors;
+
+public class MuteListCommand implements CommandExecutor {
+
+	Chat plugin = null;
+
+	public MuteListCommand(Chat instance) {
+		this.plugin = instance;
+	}
+
+	@Override
+	public boolean onCommand(CommandSender sender, Command cmd, String label,	String[] args) {
+		// If not our command
+		if ((!label.equalsIgnoreCase("mutelist") || args.length != 1) && 
+			(!label.equalsIgnoreCase("ch") || args.length != 2 || !args[0].equalsIgnoreCase("mutelist"))) {
+			TownyMessaging.sendErrorMsg(sender, "[TownyChat] Error: Invalid command!");
+			return false;
+		}
+			
+		if (!(sender instanceof Player)) {
+			return false; // Don't think it can happen but ...
+		}
+
+		Player player = ((Player)sender);
+		
+		String name = null;
+		if (label.equalsIgnoreCase("mutelist")){
+			name = args[0];
+		} else {
+			name = args[1];
+		}
+		
+		String mutePerm = plugin.getChannelsHandler().getMutePermission();
+		String unmutePerm = plugin.getChannelsHandler().getUnmutePermission();
+		if ((mutePerm == null && unmutePerm == null) || 
+			(mutePerm != null && (plugin.getTowny().isPermissions() && !TownyUniverse.getPermissionSource().has(player, mutePerm))) ||
+			(unmutePerm != null && (plugin.getTowny().isPermissions() && !TownyUniverse.getPermissionSource().has(player, unmutePerm)))) {
+			TownyMessaging.sendErrorMsg(sender, "[TownyChat] You don't have permissions to see mute list");
+			return true;
+		}
+
+		Channel chan = plugin.getChannelsHandler().getChannel(name);
+
+		// If we can't find the channel by name, look up all the channel commands for an alias
+		if (chan == null) {
+			for(Channel chan2 : plugin.getChannelsHandler().getAllChannels().values()) {
+				for (String command : chan2.getCommands()) {
+					if (command.equalsIgnoreCase(name)) {
+						chan = chan2;
+						break;
+					}
+				}
+				if (chan != null) {
+					break;
+				}
+			}
+		}
+				
+		if (chan == null) {
+			TownyMessaging.sendErrorMsg(sender, "[TownyChat] There is no channel called " + Colors.White + name);
+			return true;
+		}
+
+		name = chan.getName();
+		
+		// TODO Support paging through this list
+		int count = 0;
+		Iterator<String> iter = chan.getMuteList().iterator();
+		boolean first = true;
+		String players = "";
+		while(iter.hasNext()) {
+			if (!first) {
+				players += Colors.Green + ", "+ Colors.White;
+			}
+			players += iter.next();
+			count++;
+		}
+
+		if (count == 0) {
+			TownyMessaging.sendMsg(sender, "[TownyChat] There are no muted playeers in " + Colors.White + chan.getName());
+			return true;
+		}
+		
+		String msg = "[TownyChat] " + Colors.White + count + Colors.Green + " players muted in " + Colors.White + chan.getName() + Colors.Green + ": " + Colors.White + players;
+
+		TownyMessaging.sendMsg(sender, msg);
+		return true;
+	}
+}

--- a/src/com/palmergames/bukkit/TownyChat/Command/UnmuteCommand.java
+++ b/src/com/palmergames/bukkit/TownyChat/Command/UnmuteCommand.java
@@ -36,7 +36,7 @@ public class UnmuteCommand implements CommandExecutor {
 		
 		String name = null;
 		String mutee = null;
-		if (label.equalsIgnoreCase("mute")){
+		if (label.equalsIgnoreCase("unmute")){
 			name = args[0];
 			mutee = args[1];
 		} else {

--- a/src/com/palmergames/bukkit/TownyChat/Command/UnmuteCommand.java
+++ b/src/com/palmergames/bukkit/TownyChat/Command/UnmuteCommand.java
@@ -22,7 +22,8 @@ public class UnmuteCommand implements CommandExecutor {
 	@Override
 	public boolean onCommand(CommandSender sender, Command cmd, String label,	String[] args) {
 		// If not our command
-		if ((!label.equalsIgnoreCase("unmute") || args.length != 2) && 
+		if ((!label.equalsIgnoreCase("unmute") || args.length != 2) &&
+			(!label.equalsIgnoreCase("chunmute") || args.length != 2) && 
 			(!label.equalsIgnoreCase("ch") || args.length != 3 || !args[0].equalsIgnoreCase("unmute"))) {
 			TownyMessaging.sendErrorMsg(sender, "[TownyChat] Error: Invalid command!");
 			return false;
@@ -34,14 +35,14 @@ public class UnmuteCommand implements CommandExecutor {
 
 		Player player = ((Player)sender);
 		
-		String name = null;
+		String channelName = null;
 		String mutee = null;
-		if (label.equalsIgnoreCase("unmute")){
-			name = args[0];
+		if (label.equalsIgnoreCase("chunmute") || label.equalsIgnoreCase("unmute")){
+			channelName = args[0];
 			mutee = args[1];
 		} else {
-			name = args[1];
-			mutee = args[1];
+			channelName = args[1];
+			mutee = args[2];
 		}
 		
 		String unmutePerm = plugin.getChannelsHandler().getUnmutePermission();
@@ -58,13 +59,13 @@ public class UnmuteCommand implements CommandExecutor {
 
 		mutee = muteePlayer.getName();
 
-		Channel chan = plugin.getChannelsHandler().getChannel(name);
+		Channel chan = plugin.getChannelsHandler().getChannel(channelName);
 
 		// If we can't find the channel by name, look up all the channel commands for an alias
 		if (chan == null) {
 			for(Channel chan2 : plugin.getChannelsHandler().getAllChannels().values()) {
 				for (String command : chan2.getCommands()) {
-					if (command.equalsIgnoreCase(name)) {
+					if (command.equalsIgnoreCase(channelName)) {
 						chan = chan2;
 						break;
 					}
@@ -76,17 +77,17 @@ public class UnmuteCommand implements CommandExecutor {
 		}
 
 		if (chan == null) {
-			TownyMessaging.sendErrorMsg(sender, "[TownyChat] There is no channel called " + Colors.White + name);
+			TownyMessaging.sendErrorMsg(sender, "[TownyChat] There is no channel called " + Colors.White + channelName);
 			return true;
 		}
 
 		
-		if (!chan.mute(name)) {
+		if (!chan.mute(mutee)) {
 			TownyMessaging.sendMsg(sender, "[TownyChat] Player is not muted in "+ Colors.White + chan.getName());
 			return true;
 		}
 		
-		TownyMessaging.sendMsg(sender, "[TownyChat] " + Colors.White + name + Colors.Green +" is now muted in "+ Colors.White + chan.getName());
+		TownyMessaging.sendMsg(sender, "[TownyChat] " + Colors.White + mutee + Colors.Green +" is now muted in "+ Colors.White + chan.getName());
 		return true;
 	}
 }

--- a/src/com/palmergames/bukkit/TownyChat/Command/UnmuteCommand.java
+++ b/src/com/palmergames/bukkit/TownyChat/Command/UnmuteCommand.java
@@ -1,0 +1,92 @@
+package com.palmergames.bukkit.TownyChat.Command;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import com.palmergames.bukkit.TownyChat.Chat;
+import com.palmergames.bukkit.TownyChat.channels.Channel;
+import com.palmergames.bukkit.towny.TownyMessaging;
+import com.palmergames.bukkit.towny.object.TownyUniverse;
+import com.palmergames.bukkit.util.Colors;
+
+public class UnmuteCommand implements CommandExecutor {
+
+	Chat plugin = null;
+
+	public UnmuteCommand(Chat instance) {
+		this.plugin = instance;
+	}
+
+	@Override
+	public boolean onCommand(CommandSender sender, Command cmd, String label,	String[] args) {
+		// If not our command
+		if ((!label.equalsIgnoreCase("unmute") || args.length != 2) && 
+			(!label.equalsIgnoreCase("ch") || args.length != 3 || !args[0].equalsIgnoreCase("unmute"))) {
+			TownyMessaging.sendErrorMsg(sender, "[TownyChat] Error: Invalid command!");
+			return false;
+		}
+			
+		if (!(sender instanceof Player)) {
+			return false; // Don't think it can happen but ...
+		}
+
+		Player player = ((Player)sender);
+		
+		String name = null;
+		String mutee = null;
+		if (label.equalsIgnoreCase("mute")){
+			name = args[0];
+			mutee = args[1];
+		} else {
+			name = args[1];
+			mutee = args[1];
+		}
+		
+		String unmutePerm = plugin.getChannelsHandler().getUnmutePermission();
+		if ((unmutePerm == null) || (unmutePerm != null && (plugin.getTowny().isPermissions() && !TownyUniverse.getPermissionSource().has(player, unmutePerm)))) {
+			TownyMessaging.sendErrorMsg(sender, "[TownyChat] You don't have unmute permissions");
+			return true;
+		}
+
+		Player muteePlayer = plugin.getServer().getPlayer(mutee);
+		if (muteePlayer == null) {
+			TownyMessaging.sendErrorMsg(sender, "[TownyChat] There are no online players with name " + Colors.White + mutee);
+			return true;
+		}
+
+		mutee = muteePlayer.getName();
+
+		Channel chan = plugin.getChannelsHandler().getChannel(name);
+
+		// If we can't find the channel by name, look up all the channel commands for an alias
+		if (chan == null) {
+			for(Channel chan2 : plugin.getChannelsHandler().getAllChannels().values()) {
+				for (String command : chan2.getCommands()) {
+					if (command.equalsIgnoreCase(name)) {
+						chan = chan2;
+						break;
+					}
+				}
+				if (chan != null) {
+					break;
+				}
+			}
+		}
+
+		if (chan == null) {
+			TownyMessaging.sendErrorMsg(sender, "[TownyChat] There is no channel called " + Colors.White + name);
+			return true;
+		}
+
+		
+		if (!chan.mute(name)) {
+			TownyMessaging.sendMsg(sender, "[TownyChat] Player is not muted in "+ Colors.White + chan.getName());
+			return true;
+		}
+		
+		TownyMessaging.sendMsg(sender, "[TownyChat] " + Colors.White + name + Colors.Green +" is now muted in "+ Colors.White + chan.getName());
+		return true;
+	}
+}

--- a/src/com/palmergames/bukkit/TownyChat/Command/UnmuteCommand.java
+++ b/src/com/palmergames/bukkit/TownyChat/Command/UnmuteCommand.java
@@ -82,12 +82,12 @@ public class UnmuteCommand implements CommandExecutor {
 		}
 
 		
-		if (!chan.mute(mutee)) {
+		if (!chan.unmute(mutee)) {
 			TownyMessaging.sendMsg(sender, "[TownyChat] Player is not muted in "+ Colors.White + chan.getName());
 			return true;
 		}
 		
-		TownyMessaging.sendMsg(sender, "[TownyChat] " + Colors.White + mutee + Colors.Green +" is now muted in "+ Colors.White + chan.getName());
+		TownyMessaging.sendMsg(sender, "[TownyChat] " + Colors.White + mutee + Colors.Green +" is now unmuted in "+ Colors.White + chan.getName());
 		return true;
 	}
 }

--- a/src/com/palmergames/bukkit/TownyChat/channels/Channel.java
+++ b/src/com/palmergames/bukkit/TownyChat/channels/Channel.java
@@ -214,7 +214,12 @@ public abstract class Channel {
 	public void setLeavePermission(String permission) {
 		leavePermission = permission;;
 	}
-	
+
+	public boolean hasMuteList() {
+		if (mutedPlayers == null || mutedPlayers.isEmpty()) return false;
+		return true;
+	}
+
 	public Set<String> getMuteList() {
 		return mutedPlayers.keySet();
 	}

--- a/src/com/palmergames/bukkit/TownyChat/channels/Channel.java
+++ b/src/com/palmergames/bukkit/TownyChat/channels/Channel.java
@@ -1,7 +1,12 @@
 package com.palmergames.bukkit.TownyChat.channels;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
+import org.bukkit.entity.Player;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 
 public abstract class Channel {
@@ -9,8 +14,10 @@ public abstract class Channel {
 	private String name;
 	private List<String> commands;
 	private channelTypes type;
-	private String channelTag, messageColour, permission, craftIRCTag;
+	private String channelTag, messageColour, permission, leavePermission, craftIRCTag;
 	private double range;
+	protected ConcurrentMap<String, Integer> absentPlayers = null;  
+	protected ConcurrentMap<String, Integer> mutedPlayers = null;
 	
 	/**
 	 * Constructor
@@ -118,4 +125,97 @@ public abstract class Channel {
 	 */
 	public abstract void chatProcess(AsyncPlayerChatEvent event);
 	
+	/*
+	 * Used to reset channel settings for a given player
+	 */
+	public void forgetPlayer(String name) {
+		join(name);
+	}
+	
+	/*
+	 * Mark a player as having left chat
+	 */
+	public boolean leave(String name) {
+		if (absentPlayers == null) {
+			absentPlayers = new ConcurrentHashMap<String, Integer> ();
+		}
+		Integer res = absentPlayers.put(name, 1);
+		return (res == null || res == 0);
+	}
+	
+	/*
+	 * Mark a player has having joined the chat
+	 */
+	public boolean join(String name) {
+		if (absentPlayers == null) return false;
+		Integer res = absentPlayers.remove(name);
+		return (res != null && res == 1);
+	}
+	
+	/*
+	 * Check if a player is present in a chat
+	 */
+	public boolean isPresent(String name) {
+		if (absentPlayers == null) return true;
+		if (absentPlayers.containsKey(name)) return false;
+		return true;
+	}
+
+	/*
+	 * Check if a player is not present in a chat
+	 */
+	public boolean isAbsent(String name) {
+		return !isPresent(name);
+	}
+
+	/*
+	 * Check if a player is muted in a channel
+	 */
+	public boolean isMuted(String name) {
+		if (mutedPlayers == null) return false;
+		if (!mutedPlayers.containsKey(name)) return false;
+		return true;
+	}
+
+	/*
+	 * Mute a player
+	 */
+	public boolean mute(String name) {
+		if (mutedPlayers == null) {
+			mutedPlayers = new ConcurrentHashMap<String, Integer> ();
+		}
+		Integer i = mutedPlayers.get(name);
+		if (i != null) return false;
+		mutedPlayers.put(name, 1);
+		return true;
+	}
+
+	/*
+	 * Unmute a player 
+	 */
+	public boolean unmute(String name) {
+		if (mutedPlayers == null) return false;
+		Integer i = mutedPlayers.get(name);
+		if (i == null) return false;
+		mutedPlayers.remove(name);
+		return true;
+	}
+	
+	/*
+	 * Get name of permissions node to leave a the channel 
+	 */
+	public String getLeavePermission() {
+		return leavePermission;
+	}
+
+	/*
+	 * Set name of permissions node to leave a the channel 
+	 */
+	public void setLeavePermission(String permission) {
+		leavePermission = permission;;
+	}
+	
+	public Set<String> getMuteList() {
+		return mutedPlayers.keySet();
+	}
 }

--- a/src/com/palmergames/bukkit/TownyChat/channels/Channel.java
+++ b/src/com/palmergames/bukkit/TownyChat/channels/Channel.java
@@ -16,6 +16,7 @@ public abstract class Channel {
 	private channelTypes type;
 	private String channelTag, messageColour, permission, leavePermission, craftIRCTag;
 	private double range;
+	private boolean hooked=false;
 	protected ConcurrentMap<String, Integer> absentPlayers = null;  
 	protected ConcurrentMap<String, Integer> mutedPlayers = null;
 	
@@ -222,5 +223,13 @@ public abstract class Channel {
 
 	public Set<String> getMuteList() {
 		return mutedPlayers.keySet();
+	}
+	
+	public void setHooked(boolean hooked) {
+		this.hooked = hooked;
+	}
+
+	public boolean isHooked() {
+		return hooked;
 	}
 }

--- a/src/com/palmergames/bukkit/TownyChat/channels/Channel.java
+++ b/src/com/palmergames/bukkit/TownyChat/channels/Channel.java
@@ -1,12 +1,10 @@
 package com.palmergames.bukkit.TownyChat.channels;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import org.bukkit.entity.Player;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 
 public abstract class Channel {
@@ -17,6 +15,7 @@ public abstract class Channel {
 	private String channelTag, messageColour, permission, leavePermission, craftIRCTag;
 	private double range;
 	private boolean hooked=false;
+	private boolean autojoin=true;
 	protected ConcurrentMap<String, Integer> absentPlayers = null;  
 	protected ConcurrentMap<String, Integer> mutedPlayers = null;
 	
@@ -130,7 +129,13 @@ public abstract class Channel {
 	 * Used to reset channel settings for a given player
 	 */
 	public void forgetPlayer(String name) {
-		join(name);
+		// If the channel is auto join, they will be added
+		// If the channel is not auto join, they will marked as absent
+		if (autojoin) {
+			join(name);
+		} else {
+			leave(name);
+		}
 	}
 	
 	/*
@@ -231,5 +236,13 @@ public abstract class Channel {
 
 	public boolean isHooked() {
 		return hooked;
+	}
+	
+	public void setAutoJoin(boolean autojoin) {
+		this.autojoin = autojoin;
+	}
+	
+	public boolean isAutoJoin() {
+		return autojoin;
 	}
 }

--- a/src/com/palmergames/bukkit/TownyChat/channels/ChannelsHolder.java
+++ b/src/com/palmergames/bukkit/TownyChat/channels/ChannelsHolder.java
@@ -84,6 +84,49 @@ public class ChannelsHolder {
 	
 	
 	/**
+	 * Find a channel we are able to talk in, and have not left, starting with the greatest range.
+	 * 
+	 * @param player
+	 * @param type
+	 * @return channel or null if none.
+	 */
+	public Channel getActiveChannel(Player player, channelTypes type) {
+		
+		Channel local = null;
+		Channel global = null;
+		Channel world = null;
+		
+		String name = player.getName();
+		
+		for (Channel channel: channels.values()) {
+			if (!channel.isPresent(name)) continue;
+			if (!channel.getType().equals(type)) continue;
+			if (!plugin.getTowny().isPermissions() || 
+				(plugin.getTowny().isPermissions() && ((TownyUniverse.getPermissionSource().has(player, channel.getPermission())) || 
+						                               (channel.getPermission().isEmpty())))) {
+				if (channel.getRange() == -1) {
+					global = channel;
+				} else if (channel.getRange() == 0) {
+					world = channel;
+				} else
+					local = channel;
+			}
+		}
+		
+		if (global != null)
+			return global;
+		
+		if (world != null)
+			return world;
+		
+		if (local != null)
+			return local;
+		
+		return null;
+	}
+	
+	
+	/**
 	 * Find a channel we are able to talk in, starting with the greatest range.
 	 * 
 	 * @param player
@@ -97,17 +140,16 @@ public class ChannelsHolder {
 		Channel world = null;
 		
 		for (Channel channel: channels.values()) {
-			if (channel.getType().equals(type)) {
-				if (!plugin.getTowny().isPermissions()
-					|| (plugin.getTowny().isPermissions() && ((TownyUniverse.getPermissionSource().has(player, channel.getPermission()))
-														|| (channel.getPermission().isEmpty())))) {
-					if (channel.getRange() == -1) {
-						global = channel;
-					} else if (channel.getRange() == 0) {
-						world = channel;
-					} else
-						local = channel;
-				}
+			if (!channel.getType().equals(type)) continue;
+			if (!plugin.getTowny().isPermissions() || 
+					(plugin.getTowny().isPermissions() && ((TownyUniverse.getPermissionSource().has(player, channel.getPermission())) || 
+							                               (channel.getPermission().isEmpty())))) {
+				if (channel.getRange() == -1) {
+					global = channel;
+				} else if (channel.getRange() == 0) {
+					world = channel;
+				} else
+					local = channel;
 			}
 		}
 		
@@ -141,5 +183,11 @@ public class ChannelsHolder {
 		return perms;
 	}
 
+	public String getMutePermission() {
+		return "townychat.mod.mute";
+	}
 
+	public String getUnmutePermission() {
+		return "townychat.mod.unmute";
+	}
 }

--- a/src/com/palmergames/bukkit/TownyChat/channels/ChannelsHolder.java
+++ b/src/com/palmergames/bukkit/TownyChat/channels/ChannelsHolder.java
@@ -17,6 +17,7 @@ import com.palmergames.bukkit.towny.object.TownyUniverse;
 public class ChannelsHolder {
 	
 	private Chat plugin;
+	private Channel defaultChan = null;
 	
 	/** Constructor
 	 * 
@@ -27,6 +28,13 @@ public class ChannelsHolder {
 		this.plugin = plugin;
 	}
 
+	public void setDefaultChannel(Channel channel) {
+		defaultChan = channel;
+	}
+	
+	public Channel getDefaultChannel() {
+		return defaultChan;
+	}
 	
 	// Container for all channels
 	private Map<String,Channel> channels = new HashMap<String,Channel>();

--- a/src/com/palmergames/bukkit/TownyChat/channels/StandardChannel.java
+++ b/src/com/palmergames/bukkit/TownyChat/channels/StandardChannel.java
@@ -32,6 +32,7 @@ public class StandardChannel extends Channel {
 		this.plugin = instance;
 	}
 
+
 	@Override
 	public void chatProcess(AsyncPlayerChatEvent event) {
 		
@@ -51,7 +52,6 @@ public class StandardChannel extends Channel {
 		} catch (NotRegisteredException e1) {
 			// Not in a town/nation (doesn't matter which)
 		}
-		
 		
 		/*
 		 *  Retrieve the channel specific format
@@ -209,7 +209,14 @@ public class StandardChannel extends Channel {
 							// Failed to fetch user so ignore.
 						}
 					}
-	        		
+
+	        		// Spy's can leave channels and we'll respect that
+	        		if (absentPlayers != null) {
+	        			// Ignore players who have left this channel
+	        			if (absentPlayers.containsKey(test.getName())) {
+	        				continue;
+	        			}
+	        		}
 	        		recipients.add(test);
 	        	}
         	}
@@ -220,5 +227,4 @@ public class StandardChannel extends Channel {
         
         return recipients;
 	}
-
 }

--- a/src/com/palmergames/bukkit/TownyChat/channels/StandardChannel.java
+++ b/src/com/palmergames/bukkit/TownyChat/channels/StandardChannel.java
@@ -5,8 +5,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.logging.Level;
-
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
@@ -19,6 +17,7 @@ import com.palmergames.bukkit.TownyChat.TownyChatFormatter;
 import com.palmergames.bukkit.TownyChat.config.ChatSettings;
 import com.palmergames.bukkit.TownyChat.events.AsyncChatHookEvent;
 import com.palmergames.bukkit.TownyChat.listener.LocalTownyChatEvent;
+import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
 import com.palmergames.bukkit.towny.exceptions.TownyException;
 import com.palmergames.bukkit.towny.object.Nation;
@@ -26,6 +25,7 @@ import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownyUniverse;
 import com.palmergames.bukkit.util.BukkitTools;
+import com.palmergames.bukkit.util.Colors;
 
 public class StandardChannel extends Channel {
 
@@ -56,6 +56,14 @@ public class StandardChannel extends Channel {
 			// Not in a town/nation (doesn't matter which)
 		}
 		
+		boolean notifyjoin = false;
+		// If player sends a message to a channel it had left
+		// tell the channel to add the player back
+		if (isAbsent(player.getName())) {
+			join(player.getName());
+			notifyjoin = true;
+		}
+
 		/*
 		 *  Retrieve the channel specific format
 		 *  and compile a set of recipients
@@ -123,7 +131,11 @@ public class StandardChannel extends Channel {
                 event.getRecipients().addAll(hookEvent.getRecipients());
             }
         }
-        
+
+        if (notifyjoin) {
+			TownyMessaging.sendMsg(player, "You join " + Colors.White + getName());
+        }
+
         /*
          * Perform any last channel specific functions
          * like logging this chat and relaying to IRC/Dynmap.

--- a/src/com/palmergames/bukkit/TownyChat/config/ConfigurationHandler.java
+++ b/src/com/palmergames/bukkit/TownyChat/config/ConfigurationHandler.java
@@ -88,6 +88,16 @@ public class ConfigurationHandler {
 									}
 								}
 
+								if (key.equalsIgnoreCase("autojoin")) {
+									if (element instanceof Boolean) {
+										channel.setAutoJoin((Boolean)element);
+									} else if (element instanceof String) {
+										channel.setAutoJoin(Boolean.parseBoolean(element.toString()));
+									} else if (element instanceof Integer) {
+										channel.setAutoJoin(Integer.parseInt(element.toString()) != 0);
+									}
+								}
+
 								if (key.equalsIgnoreCase("channeltag"))
 									if (element instanceof String)
 										channel.setChannelTag(element.toString());

--- a/src/com/palmergames/bukkit/TownyChat/config/ConfigurationHandler.java
+++ b/src/com/palmergames/bukkit/TownyChat/config/ConfigurationHandler.java
@@ -7,8 +7,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-
-
 import com.palmergames.bukkit.TownyChat.Chat;
 import com.palmergames.bukkit.TownyChat.channels.Channel;
 import com.palmergames.bukkit.TownyChat.channels.StandardChannel;
@@ -95,6 +93,21 @@ public class ConfigurationHandler {
 										channel.setAutoJoin(Boolean.parseBoolean(element.toString()));
 									} else if (element instanceof Integer) {
 										channel.setAutoJoin(Integer.parseInt(element.toString()) != 0);
+									}
+								}
+
+								if (key.equalsIgnoreCase("default")) {
+									boolean set = false;
+									if (element instanceof Boolean) {
+										set = (element != null && ((Boolean)element) == true);
+									} else if (element instanceof String) {
+										set = Boolean.parseBoolean((String)element);
+									} else if (element instanceof Integer) {
+										set = (element != null && ((Integer)element) != 0);
+									}
+									if (set) {
+										plugin.getChannelsHandler().setDefaultChannel(channel);
+										plugin.getLogger().info("Default Channel set to " + channel.getName());
 									}
 								}
 

--- a/src/com/palmergames/bukkit/TownyChat/config/ConfigurationHandler.java
+++ b/src/com/palmergames/bukkit/TownyChat/config/ConfigurationHandler.java
@@ -90,6 +90,10 @@ public class ConfigurationHandler {
 									if (element instanceof String)
 										channel.setPermission(element.toString());
 								
+								if (key.equalsIgnoreCase("leavepermission"))
+									if (element instanceof String)
+										channel.setLeavePermission(element.toString());
+
 								if (key.equalsIgnoreCase("craftIRCTag"))
 									if (element instanceof String)
 										channel.setCraftIRCTag(element.toString());
@@ -98,6 +102,10 @@ public class ConfigurationHandler {
 									channel.setRange(Double.valueOf(element.toString()));
 							}
 							
+							// If no leave permission is set, create a default permission name
+							if (channel.getLeavePermission() == null) {
+								channel.setLeavePermission("towny.chat.leave." + channel.getName().toLowerCase());
+							}
 							plugin.getChannelsHandler().addChannel(channel);
 							
 							//System.out.print("Channel: " + channel.getName() + " : Type : " + channel.getType().name());

--- a/src/com/palmergames/bukkit/TownyChat/config/ConfigurationHandler.java
+++ b/src/com/palmergames/bukkit/TownyChat/config/ConfigurationHandler.java
@@ -77,7 +77,17 @@ public class ConfigurationHandler {
 								if (key.equalsIgnoreCase("type"))
 									if (element instanceof String)
 										channel.setType(channelTypes.valueOf(element.toString()));
-		
+
+								if (key.equalsIgnoreCase("hooked")) {
+									if (element instanceof Boolean) {
+										channel.setHooked((Boolean)element);
+									} else if (element instanceof String) {
+										channel.setHooked(Boolean.parseBoolean(element.toString()));
+									} else if (element instanceof Integer) {
+										channel.setHooked(Integer.parseInt(element.toString()) != 0);
+									}
+								}
+
 								if (key.equalsIgnoreCase("channeltag"))
 									if (element instanceof String)
 										channel.setChannelTag(element.toString());

--- a/src/com/palmergames/bukkit/TownyChat/events/AsyncChatHookEvent.java
+++ b/src/com/palmergames/bukkit/TownyChat/events/AsyncChatHookEvent.java
@@ -66,23 +66,23 @@ public class AsyncChatHookEvent extends Event {
 		return event.getPlayer();
 	}
 	
-	public void SetRecipients(Set<Player> recipients) {
+	public void setRecipients(Set<Player> recipients) {
 		changed = true;
 		event.getRecipients().clear();
 		event.getRecipients().addAll(recipients);
 	}
 	
-	public void SetFormat(String format) {
+	public void setFormat(String format) {
 		changed = true;
 		event.setFormat(format);
 	}
 	
-	public void SetMessage(String message) {
+	public void setMessage(String message) {
 		changed = true;
 		event.setFormat(message);
 	}
 	
-	public void SetCancelled(boolean cancel) {
+	public void setCancelled(boolean cancel) {
 		changed = (cancel == true);
 		event.setCancelled(cancel);
 	}

--- a/src/com/palmergames/bukkit/TownyChat/events/AsyncChatHookEvent.java
+++ b/src/com/palmergames/bukkit/TownyChat/events/AsyncChatHookEvent.java
@@ -1,0 +1,98 @@
+package com.palmergames.bukkit.TownyChat.events;
+
+import java.util.Set;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+
+import com.palmergames.bukkit.TownyChat.channels.Channel;
+
+/*
+ * Allows other plugins to hook into a chat message being accepted into any of the channels
+ */
+public class AsyncChatHookEvent extends Event {
+    private static final HandlerList handlers = new HandlerList();
+	protected AsyncPlayerChatEvent event = null;
+	protected boolean changed = false;
+	protected Channel channel=null;
+
+	public AsyncChatHookEvent(AsyncPlayerChatEvent event, Channel channel) {
+		this.event = event;
+		this.changed = false;
+		this.channel = channel;
+	}
+
+	public Channel getChannel() {
+		return channel;
+	}
+
+	/*
+	 * Returns true if the hooked event was changed
+	 */
+	public boolean isChanged() {
+		return changed;
+	}
+
+	/*
+	 * Informs TownyChat if the event was changed or not
+	 */
+	public void setChanged(boolean changed) {
+		this.changed = changed;
+	}
+
+	public AsyncPlayerChatEvent getAsyncPlayerChatEvent() {
+		return event;
+	}
+	
+	public String getFormat() {
+		return event.getFormat();
+	}
+	
+	public String getMessage() {
+		return event.getMessage();
+	}
+	
+	public Set<Player> getRecipients() {
+		return event.getRecipients();
+	}
+	
+	public boolean isCancelled() {
+		return event.isCancelled();
+	}
+	
+	public Player getPlayer() {
+		return event.getPlayer();
+	}
+	
+	public void SetRecipients(Set<Player> recipients) {
+		changed = true;
+		event.getRecipients().clear();
+		event.getRecipients().addAll(recipients);
+	}
+	
+	public void SetFormat(String format) {
+		changed = true;
+		event.setFormat(format);
+	}
+	
+	public void SetMessage(String message) {
+		changed = true;
+		event.setFormat(message);
+	}
+	
+	public void SetCancelled(boolean cancel) {
+		changed = (cancel == true);
+		event.setCancelled(cancel);
+	}
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/com/palmergames/bukkit/TownyChat/listener/TownyChatPlayerListener.java
+++ b/src/com/palmergames/bukkit/TownyChat/listener/TownyChatPlayerListener.java
@@ -17,6 +17,7 @@ import com.palmergames.bukkit.TownyChat.channels.channelTypes;
 import com.palmergames.bukkit.TownyChat.config.ChatSettings;
 import com.palmergames.bukkit.TownyChat.listener.LocalTownyChatEvent;
 import com.palmergames.bukkit.TownyChat.tasks.onPlayerJoinTask;
+import com.palmergames.bukkit.TownyChat.util.TownyUtil;
 import com.palmergames.bukkit.TownyChat.Chat;
 import com.palmergames.bukkit.TownyChat.TownyChatFormatter;
 import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
@@ -93,11 +94,27 @@ public class TownyChatPlayerListener implements Listener  {
 			 *  If there is no message toggle the chat mode.
 			 */
 			if (message.isEmpty()) {
-				if (plugin.getTowny().hasPlayerMode(player, channel.getName()))
+				if (plugin.getTowny().hasPlayerMode(player, channel.getName())) {
 					plugin.getTowny().removePlayerMode(player);
-				else
+					// Find what the next channel is if any
+					Channel nextChannel = null;
+					if (plugin.getChannelsHandler().getDefaultChannel() != null && plugin.getChannelsHandler().getDefaultChannel().isPresent(player.getName())) {
+						nextChannel = plugin.getChannelsHandler().getDefaultChannel();
+						TownyUtil.addPlayerMode(plugin.getTowny(), player, nextChannel.getName(), true);
+					}
+					if (nextChannel == null) {
+						nextChannel = plugin.getChannelsHandler().getActiveChannel(player, channelTypes.GLOBAL);
+					}
+					
+					// If the new channel is not us, announce it
+					if (nextChannel != null && !channel.getName().equalsIgnoreCase(nextChannel.getName())) {
+						TownyMessaging.sendMsg(player, "[TownyChat] You are now talking in " + Colors.White + nextChannel.getName());
+					}
+				}
+				else {
 					plugin.getTowny().setPlayerMode(player, new String[]{channel.getName()}, true);
-
+					TownyMessaging.sendMsg(player, "[TownyChat] You are now talking in " + Colors.White + channel.getName());
+				}
 			} else {
 				// Notify player he is muted
 				if (channel.isMuted(player.getName())) {
@@ -203,7 +220,6 @@ public class TownyChatPlayerListener implements Listener  {
 				e.printStackTrace();
 			}
 		}
-
 	}
 	
 	/**

--- a/src/com/palmergames/bukkit/TownyChat/listener/TownyChatPlayerListener.java
+++ b/src/com/palmergames/bukkit/TownyChat/listener/TownyChatPlayerListener.java
@@ -8,6 +8,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
 import com.palmergames.bukkit.towny.TownyMessaging;
@@ -93,7 +94,17 @@ public class TownyChatPlayerListener implements Listener  {
 			channel.forgetPlayer(name);
 		}
 	}
-	
+
+	@EventHandler(priority = EventPriority.LOW)
+	public void onPlayerJoin(final PlayerJoinEvent event) {
+		String name = event.getPlayer().getName(); 
+		for (Channel channel : plugin.getChannelsHandler().getAllChannels().values()) {
+			// If the channel is auto join, they will be added
+			// If the channel is not auto join, they will marked as absent
+			channel.forgetPlayer(name);
+		}
+	}
+
 	@EventHandler(priority = EventPriority.LOW)
 	public void onPlayerChat(AsyncPlayerChatEvent event) {
 		

--- a/src/com/palmergames/bukkit/TownyChat/listener/TownyChatPlayerListener.java
+++ b/src/com/palmergames/bukkit/TownyChat/listener/TownyChatPlayerListener.java
@@ -95,13 +95,21 @@ public class TownyChatPlayerListener implements Listener  {
 			 */
 			if (message.isEmpty()) {
 				if (plugin.getTowny().hasPlayerMode(player, channel.getName())) {
-					plugin.getTowny().removePlayerMode(player);
 					// Find what the next channel is if any
 					Channel nextChannel = null;
 					if (plugin.getChannelsHandler().getDefaultChannel() != null && plugin.getChannelsHandler().getDefaultChannel().isPresent(player.getName())) {
 						nextChannel = plugin.getChannelsHandler().getDefaultChannel();
-						TownyUtil.addPlayerMode(plugin.getTowny(), player, nextChannel.getName(), true);
+						if (!nextChannel.getName().equalsIgnoreCase(channel.getName())) {
+							TownyUtil.removeAndSetPlayerMode(plugin.getTowny(), player, channel.getName(), nextChannel.getName(), true);
+						} else {
+							// They're talking on default channel and want to leave but can't because they'll be put default again
+							// Their only option out is to leave the channel if they have permission to do so.
+							TownyMessaging.sendErrorMsg(player, "[TownyChat] You are already talking in the default channel. To switch to another channel use that channel's command.");
+						}
+					} else {
+						plugin.getTowny().removePlayerMode(player);
 					}
+					
 					if (nextChannel == null) {
 						nextChannel = plugin.getChannelsHandler().getActiveChannel(player, channelTypes.GLOBAL);
 					}
@@ -164,6 +172,7 @@ public class TownyChatPlayerListener implements Listener  {
 						return;
 					}
 
+					plugin.getLogger().info("onPlayerChat: Processing directed message for " + channel.getName());
 					channel.chatProcess(event);
 					return;
 				}

--- a/src/com/palmergames/bukkit/TownyChat/tasks/onPlayerJoinTask.java
+++ b/src/com/palmergames/bukkit/TownyChat/tasks/onPlayerJoinTask.java
@@ -1,0 +1,43 @@
+package com.palmergames.bukkit.TownyChat.tasks;
+
+import org.bukkit.entity.Player;
+
+import com.palmergames.bukkit.TownyChat.Chat;
+import com.palmergames.bukkit.TownyChat.channels.Channel;
+import com.palmergames.bukkit.towny.Towny;
+
+/*
+ * 
+ * Created by RocketRidah
+ * 
+ */
+
+public class onPlayerJoinTask implements Runnable {
+	
+	Chat plugin;
+	Towny towny;
+	String playerName;
+	String mode;
+	
+	public onPlayerJoinTask(Chat plugin, Player player, Channel defaultChannel) {
+        super();
+        this.plugin = plugin;
+        this.towny = plugin.getTowny();
+        this.playerName = player.getName();
+        this.mode = defaultChannel.getName();
+	}
+	
+	@Override
+	public void run() {
+		if (this.towny.isEnabled()) {
+			if (!this.towny.isError()) {
+				Player player = plugin.getServer().getPlayer(playerName);
+				if (player != null) {
+					towny.setPlayerMode(player, new String[] { mode }, true);
+				}
+				return;
+			}
+		}
+	}
+	
+}

--- a/src/com/palmergames/bukkit/TownyChat/util/TownyUtil.java
+++ b/src/com/palmergames/bukkit/TownyChat/util/TownyUtil.java
@@ -18,16 +18,15 @@ public class TownyUtil {
 		}
 		
 		List<String> modes = towny.getPlayerMode(player);
-		int pos = 0;
+		int newmodecount = modes.size();
 		Iterator<String> iter = modes.iterator();
 		while (iter.hasNext()) {
 			String s = iter.next();
 			if (mode.equalsIgnoreCase(s)) {
-				modes.remove(pos);
-				towny.setPlayerMode(player, modes.toArray(new String[modes.size()]), notify);
+				iter.remove();
+				towny.setPlayerMode(player, modes.toArray(new String[newmodecount-1]), notify);
 				return true;
 			}
-			pos++;
 		}
 		return false;
 	}

--- a/src/com/palmergames/bukkit/TownyChat/util/TownyUtil.java
+++ b/src/com/palmergames/bukkit/TownyChat/util/TownyUtil.java
@@ -41,4 +41,29 @@ public class TownyUtil {
 		towny.setPlayerMode(player, modes.toArray(new String[modes.size()]), notify);
 		return true;
 	}
+
+	public static boolean removeAndSetPlayerMode(Towny towny, Player player, String removeMode, String addMode, boolean notify) {
+		List<String> modes = towny.getPlayerMode(player);
+		boolean modesChanged = false;
+		if (removeMode != null && towny.hasPlayerMode(player, removeMode)) {
+			Iterator<String> iter = modes.iterator();
+			while (iter.hasNext()) {
+				String s = iter.next();
+				if (s == null) continue;
+				if (s.equalsIgnoreCase(removeMode)) {
+					iter.remove();
+					modesChanged = true;
+				}
+			}
+		}
+		if (addMode != null) {
+			modes.add(addMode);
+			modesChanged = true;
+		}
+		if (modesChanged) {
+			towny.setPlayerMode(player, modes.toArray(new String[modes.size()]), notify);
+			return true;
+		}
+		return false;
+	}
 }

--- a/src/com/palmergames/bukkit/TownyChat/util/TownyUtil.java
+++ b/src/com/palmergames/bukkit/TownyChat/util/TownyUtil.java
@@ -1,0 +1,45 @@
+package com.palmergames.bukkit.TownyChat.util;
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.bukkit.entity.Player;
+
+import com.palmergames.bukkit.towny.Towny;
+
+public class TownyUtil {
+
+	public TownyUtil() {
+	}
+	
+	public static boolean removePlayerMode(Towny towny, Player player, String mode, boolean notify) {
+		if (!towny.hasPlayerMode(player, mode)) {
+			return false;
+		}
+		
+		List<String> modes = towny.getPlayerMode(player);
+		int pos = 0;
+		Iterator<String> iter = modes.iterator();
+		while (iter.hasNext()) {
+			String s = iter.next();
+			if (mode.equalsIgnoreCase(s)) {
+				modes.remove(pos);
+				towny.setPlayerMode(player, modes.toArray(new String[modes.size()]), notify);
+				return true;
+			}
+			pos++;
+		}
+		return false;
+	}
+
+	public static boolean addPlayerMode(Towny towny, Player player, String mode, boolean notify) {
+		if (towny.hasPlayerMode(player, mode)) {
+			return false;
+		}
+		
+		List<String> modes = towny.getPlayerMode(player);
+		modes.add(mode);
+		towny.setPlayerMode(player, modes.toArray(new String[modes.size()]), notify);
+		return true;
+	}
+}

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -23,22 +23,21 @@ commands:
         description: Channel leaving and joining
         usage: /<command> leave|join channel
     leave:
-        aliases: [ch leave]
         description: Leaves a channel
         usage: /<command> channel
     join:
-        aliases: [ch join]
         description: Joins a channel
         usage: /<command> channel
-    mute:
+    chmute:
+        aliases: [mute]
         description: Mutes a player in a channel
         usage: /<command> channel player
         permission: townychat.mod.mute
     mutelist:
         description: Displays mute list for a channel
         usage: /<command> channel
-        permission: townychat.mod.list.mute
-    unmute:
+    chunmute:
+        aliases: [unmute]
         description: Unmutes a player in a channel
         usage: /<command> channel player
         permission: townychat.mod.unmute

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -18,7 +18,31 @@ commands:
         aliases: []
         usage: /townychat reload
         permission: townychat.reload
-        
+    channel:
+        aliases: [ch]
+        description: Channel leaving and joining
+        usage: /<command> leave|join channel
+    leave:
+        aliases: [ch leave]
+        description: Leaves a channel
+        usage: /<command> channel
+    join:
+        aliases: [ch join]
+        description: Joins a channel
+        usage: /<command> channel
+    mute:
+        description: Mutes a player in a channel
+        usage: /<command> channel player
+        permission: townychat.mod.mute
+    mutelist:
+        description: Displays mute list for a channel
+        usage: /<command> channel
+        permission: townychat.mod.list.mute
+    unmute:
+        description: Unmutes a player in a channel
+        usage: /<command> channel player
+        permission: townychat.mod.unmute
+            
 ############################################################
 # +------------------------------------------------------+ #
 # |                     Permissions                      | #


### PR DESCRIPTION
New features
- Support for joining and leaving channels
- Support for configuration of a channel as default channel when more than one GLOBAL
- Support for channel AutoJoin being false and not join all channels on login
- Support for Mute/Unmute per Channel
- Support for notifying other plugins of a message being accepted into chat using TownyChatAsyncChatEvent
- Fixes ant build script to include line numbers when compiling

New Permissions
- towny.chat.leave.<channel name>
  Gives permission owner the ability to leave a channel
- townychat.mod.unmute
  Giver permission owner the ability to unmute people in any channel 
- townychat.mod.mute
      Giver permission owner the ability to mute people in any channel

All of the above require extra configuration to enable or disable. The default functionality is the same as the current TownyChat. 

If you'd prefer separate individual pull requests for each of the features let me know :-)
