### PR TITLE
Ignore already cancelled chat events

### DIFF
--- a/src/com/palmergames/bukkit/TownyChat/listener/TownyChatPlayerListener.java
+++ b/src/com/palmergames/bukkit/TownyChat/listener/TownyChatPlayerListener.java
@@ -69,7 +69,7 @@ public class TownyChatPlayerListener implements Listener  {
 		}
 	}
 
-	@EventHandler(priority = EventPriority.LOWEST)
+	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
 	public void onPlayerCommandPreprocess(PlayerCommandPreprocessEvent event) {
 		
 		final Player player = event.getPlayer();
@@ -155,7 +155,7 @@ public class TownyChatPlayerListener implements Listener  {
 		}
 	}
 	
-	@EventHandler(priority = EventPriority.LOW)
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void onPlayerChat(AsyncPlayerChatEvent event) {
 		
 		Player player = event.getPlayer();


### PR DESCRIPTION
I manage a plugin agains server advertising that 'delays' suspicious chat messages for further inspection by cancelling them and resending them later.
In combination with the TownyChat spam prevention, every message that is delayed and resent in less than 2 seconds is considered spam although the first message has been cancelled.

In addition, I don't think it's not necessary to check cancelled events at all.
