### PR TITLE
added coalition chat, for nation alliances

### DIFF
--- a/src/Channels.yml
+++ b/src/Channels.yml
@@ -21,8 +21,8 @@
 # range is in blocks (if set to a limit).
 #
 #     -1 = no limits
-#	  0 = same world only
-#	  any positive value = limited range in the same world.
+#    0 = same world only
+#    any positive value = limited range in the same world.
 
 # Text colouring
 # --------------
@@ -49,12 +49,21 @@ Channels:
         permission: 'towny.chat.town'
         craftIRCTag: 'admin'
         range: '-1'
-         
+        
     nation:
         commands: [nc]
         type: NATION
         channeltag: '&f[&6NC&f]'
         messagecolour: '&e'
+        permission: 'towny.chat.nation'
+        craftIRCTag: 'admin'
+        range: '-1'
+        
+    coalition:
+        commands: [cc]
+        type: COALITION
+        channeltag: '&f[&9CC&f]'
+        messagecolour: '&d'
         permission: 'towny.chat.nation'
         craftIRCTag: 'admin'
         range: '-1'

--- a/src/ChatConfig.yml
+++ b/src/ChatConfig.yml
@@ -60,6 +60,8 @@
     town: '[townformat]'
     # NATION channel types.
     nation: '[nationformat]'
+    # COALITION channel types.
+    coalition: '[coalitionformat]'
     # DEFAULT channel types.
     default: '[defaultformat]'
     

--- a/src/com/palmergames/bukkit/TownyChat/channels/StandardChannel.java
+++ b/src/com/palmergames/bukkit/TownyChat/channels/StandardChannel.java
@@ -46,12 +46,16 @@ public class StandardChannel extends Channel {
 		Resident resident = null;
 		Town town = null;
 		Nation nation = null;
+		List<Nation> coalition = null;
 		String Format = "";
 		
 		try {
 			resident = TownyUniverse.getDataSource().getResident(player.getName());
 			town = resident.getTown();
 			nation = resident.getTown().getNation();
+			coalition = nation.getAllies();
+			coalition.add(nation);
+
 		} catch (NotRegisteredException e1) {
 			// Not in a town/nation (doesn't matter which)
 		}
@@ -65,8 +69,8 @@ public class StandardChannel extends Channel {
 		}
 
 		/*
-		 *  Retrieve the channel specific format
-		 *  and compile a set of recipients
+		 *	Retrieve the channel specific format
+		 *	and compile a set of recipients
 		 */
 		switch (exec) {
 		
@@ -87,6 +91,20 @@ public class StandardChannel extends Channel {
 			}
 			Format = ChatSettings.getRelevantFormatGroup(player).getNATION();
 			recipients = new HashSet<Player>(findRecipients(player, TownyUniverse.getOnlinePlayers(nation)));
+			recipients = checkSpying(recipients);
+			break;
+		
+		case COALITION:
+			if (coalition == null) {
+				event.setCancelled(true);
+				return;
+			}
+			Format = ChatSettings.getRelevantFormatGroup(player).getCOALITION();
+			//recipients = new HashSet<Player>(findRecipients(player, TownyUniverse.getOnlinePlayers(coalition)));
+			recipients = new HashSet<Player>();
+			for(Nation ally : coalition) {
+				recipients.addAll(findRecipients(player, TownyUniverse.getOnlinePlayers(ally)));
+			}
 			recipients = checkSpying(recipients);
 			break;
 			
@@ -118,37 +136,37 @@ public class StandardChannel extends Channel {
 		event.setFormat(TownyChatFormatter.getChatFormat(chatEvent));
 		
 		/*
-		 *  Set all the listeners for Bukkit to send this message to.
+		 *	Set all the listeners for Bukkit to send this message to.
 		 */
-        event.getRecipients().clear();
-        event.getRecipients().addAll(recipients);
-        
-        if (isHooked()) {
-        	AsyncChatHookEvent hookEvent = new AsyncChatHookEvent(event, this);
-            Bukkit.getServer().getPluginManager().callEvent(hookEvent);
-            if (hookEvent.isCancelled()) {
-            	event.setCancelled(true);
-            	return;
-            }
-            if (hookEvent.isChanged()) {
-            	event.setMessage(hookEvent.getMessage());
-            	event.setFormat(hookEvent.getFormat());
-                event.getRecipients().clear();
-                event.getRecipients().addAll(hookEvent.getRecipients());
-            }
-        }
+				event.getRecipients().clear();
+				event.getRecipients().addAll(recipients);
+				
+				if (isHooked()) {
+					AsyncChatHookEvent hookEvent = new AsyncChatHookEvent(event, this);
+						Bukkit.getServer().getPluginManager().callEvent(hookEvent);
+						if (hookEvent.isCancelled()) {
+							event.setCancelled(true);
+							return;
+						}
+						if (hookEvent.isChanged()) {
+							event.setMessage(hookEvent.getMessage());
+							event.setFormat(hookEvent.getFormat());
+								event.getRecipients().clear();
+								event.getRecipients().addAll(hookEvent.getRecipients());
+						}
+				}
 
-        if (notifyjoin) {
+				if (notifyjoin) {
 			TownyMessaging.sendMsg(player, "You join " + Colors.White + getName());
-        }
+				}
 
-        /*
-         * Perform any last channel specific functions
-         * like logging this chat and relaying to IRC/Dynmap.
-         */
-        String msg = event.getFormat().replace("%1$s", event.getPlayer().getDisplayName()).replace("%2$s", event.getMessage());
-        
-        switch (exec) {
+				/*
+				 * Perform any last channel specific functions
+				 * like logging this chat and relaying to IRC/Dynmap.
+				 */
+				String msg = event.getFormat().replace("%1$s", event.getPlayer().getDisplayName()).replace("%2$s", event.getMessage());
+				
+				switch (exec) {
 		
 		case TOWN:
 			//plugin.getLogger().info(ChatTools.stripColour("[Town Msg] " + town.getName() + ": " + msg));
@@ -157,7 +175,11 @@ public class StandardChannel extends Channel {
 		case NATION:
 			//plugin.getLogger().info(ChatTools.stripColour("[Nation Msg] " + nation.getName() + ": " + msg));
 			break;
-			
+		
+		case COALITION:
+			//plugin.getLogger().info(ChatTools.stripColour("[Coalition Msg] " + nation.getName() + ": " + msg));
+			break;
+		
 		case DEFAULT:
 			break;
 			
@@ -169,11 +191,11 @@ public class StandardChannel extends Channel {
 				dynMap.postPlayerMessageToWeb(player, event.getMessage());
 			break;
 		}
-        
-        // Relay to IRC
-        CraftIRCHandler ircHander = plugin.getIRC();
-        if (ircHander != null)
-        	ircHander.IRCSender(msg, getCraftIRCTag());
+				
+				// Relay to IRC
+				CraftIRCHandler ircHander = plugin.getIRC();
+				if (ircHander != null)
+					ircHander.IRCSender(msg, getCraftIRCTag());
 		
 	}
 
@@ -219,24 +241,24 @@ public class StandardChannel extends Channel {
 		String sendersName = sender.getName();
 		
 		// Compile the list of recipients
-        for (Player test : list) {
-        	
-        	/*
-        	 * If Not using permissions, or the player has the correct permission node.
-        	 */
-        	if (!plugin.getTowny().isPermissions() || (plugin.getTowny().isPermissions() && TownyUniverse.getPermissionSource().has(test, getPermission()))) {
-        		
-        		/*
-        		 * If the player is within range for this channel
-        		 * or the recipient has the spy mode.
-        		 */
-	        	if ((testDistance(sender, test, getRange())) || (plugin.getTowny().hasPlayerMode(test, "spy"))) {
-	        		
-	        		if (bEssentials) {
+				for (Player test : list) {
+					
+					/*
+					 * If Not using permissions, or the player has the correct permission node.
+					 */
+					if (!plugin.getTowny().isPermissions() || (plugin.getTowny().isPermissions() && TownyUniverse.getPermissionSource().has(test, getPermission()))) {
+						
+						/*
+						 * If the player is within range for this channel
+						 * or the recipient has the spy mode.
+						 */
+						if ((testDistance(sender, test, getRange())) || (plugin.getTowny().hasPlayerMode(test, "spy"))) {
+							
+							if (bEssentials) {
 						try {
 							User targetUser = plugin.getTowny().getEssentials().getUser(test);
 							/*
-							 *  Don't send this message if the user is ignored
+							 *	Don't send this message if the user is ignored
 							 */
 							if (targetUser.isIgnoredPlayer(sendersName))
 								continue;
@@ -245,22 +267,22 @@ public class StandardChannel extends Channel {
 						}
 					}
 
-	        		// Spy's can leave channels and we'll respect that
-	        		if (absentPlayers != null) {
-	        			// Ignore players who have left this channel
-	        			if (absentPlayers.containsKey(test.getName())) {
-	        				continue;
-	        			}
-	        		}
-	        		recipients.add(test);
-	        	}
-        	}
-        }
-        
-        //if (recipients.size() <= 1)
-        //	sender.sendMessage(TownySettings.parseSingleLineString("&cYou feel so lonely."));
-        
-        return recipients;
+							// Spy's can leave channels and we'll respect that
+							if (absentPlayers != null) {
+								// Ignore players who have left this channel
+								if (absentPlayers.containsKey(test.getName())) {
+									continue;
+								}
+							}
+							recipients.add(test);
+						}
+					}
+				}
+				
+				//if (recipients.size() <= 1)
+				//	sender.sendMessage(TownySettings.parseSingleLineString("&cYou feel so lonely."));
+				
+				return recipients;
 	}
 	
 	/**
@@ -274,13 +296,13 @@ public class StandardChannel extends Channel {
 		List<Player> allOnline = new ArrayList<Player>(Arrays.asList(BukkitTools.getOnlinePlayers()));
 		
 		// Compile the list of recipients with spy perms
-        for (Player test : allOnline) {
-        	
-        	if ((plugin.getTowny().hasPlayerMode(test, "spy")) && !(recipients.contains(test))) {
-        		recipients.add(test);
-        	}
+				for (Player test : allOnline) {
+					
+					if ((plugin.getTowny().hasPlayerMode(test, "spy")) && !(recipients.contains(test))) {
+						recipients.add(test);
+					}
 
-        }
+				}
 		
 		return recipients;
 	}

--- a/src/com/palmergames/bukkit/TownyChat/channels/StandardChannel.java
+++ b/src/com/palmergames/bukkit/TownyChat/channels/StandardChannel.java
@@ -46,14 +46,14 @@ public class StandardChannel extends Channel {
 		Resident resident = null;
 		Town town = null;
 		Nation nation = null;
-		List<Nation> coalition = null;
+		List<Nation> coalition = new ArrayList<Nation>();
 		String Format = "";
 		
 		try {
 			resident = TownyUniverse.getDataSource().getResident(player.getName());
 			town = resident.getTown();
 			nation = resident.getTown().getNation();
-			coalition = nation.getAllies();
+			coalition.addAll(nation.getAllies());
 			coalition.add(nation);
 
 		} catch (NotRegisteredException e1) {
@@ -95,7 +95,7 @@ public class StandardChannel extends Channel {
 			break;
 		
 		case COALITION:
-			if (coalition == null) {
+			if (coalition.isEmpty()) {
 				event.setCancelled(true);
 				return;
 			}

--- a/src/com/palmergames/bukkit/TownyChat/channels/channelFormats.java
+++ b/src/com/palmergames/bukkit/TownyChat/channels/channelFormats.java
@@ -14,7 +14,7 @@ public class channelFormats {
 		this.name = name.toLowerCase();
 	}
 
-	private String name, GLOBAL, TOWN, NATION, DEFAULT;
+	private String name, GLOBAL, TOWN, NATION, COALITION, DEFAULT;
 
 	/**
 	 * @return a clone of this channelFormats
@@ -26,6 +26,7 @@ public class channelFormats {
 		clone.setGLOBAL(this.getGLOBAL());
 		clone.setTOWN(this.getTOWN());
 		clone.setNATION(this.getNATION());
+		clone.setCOALITION(this.getCOALITION());
 		clone.setDEFAULT(this.getDEFAULT());
 		
 		return clone;
@@ -40,7 +41,7 @@ public class channelFormats {
 
 	/**
 	 * @param name
-	 *            the name to set
+	 *						the name to set
 	 */
 	public void setName(String name) {
 		this.name = name;
@@ -55,7 +56,7 @@ public class channelFormats {
 
 	/**
 	 * @param GLOBAL
-	 *            the gLOBAL to set
+	 *						the gLOBAL to set
 	 */
 	public void setGLOBAL(String GLOBAL) {
 		this.GLOBAL = GLOBAL;
@@ -70,7 +71,7 @@ public class channelFormats {
 
 	/**
 	 * @param TOWN
-	 *            the TOWN to set
+	 *						the TOWN to set
 	 */
 	public void setTOWN(String TOWN) {
 		this.TOWN = TOWN;
@@ -85,10 +86,26 @@ public class channelFormats {
 
 	/**
 	 * @param NATION
-	 *            the nATION to set
+	 *						the NATION to set
 	 */
 	public void setNATION(String NATION) {
 		this.NATION = NATION;
+	}
+	
+	/**
+	 * @return the COALITION
+	 */
+	public String getCOALITION() {
+		return this.COALITION;
+	}
+
+	/**
+
+	 * @param COALITION
+	 *						the COALITION to set
+	 */
+	public void setCOALITION(String COALITION) {
+		this.COALITION = COALITION;
 	}
 
 	/**
@@ -100,7 +117,7 @@ public class channelFormats {
 
 	/**
 	 * @param DEFAULT
-	 *            the dEFAULT to set
+	 *						the dEFAULT to set
 	 */
 	public void setDEFAULT(String DEFAULT) {
 		this.DEFAULT = DEFAULT;

--- a/src/com/palmergames/bukkit/TownyChat/channels/channelTypes.java
+++ b/src/com/palmergames/bukkit/TownyChat/channels/channelTypes.java
@@ -4,6 +4,7 @@ package com.palmergames.bukkit.TownyChat.channels;
 public enum channelTypes {
 	TOWN,
 	NATION,
+	COALITION,
 	DEFAULT,
 	GLOBAL,
 	PRIVATE

--- a/src/com/palmergames/bukkit/TownyChat/config/ChatSettings.java
+++ b/src/com/palmergames/bukkit/TownyChat/config/ChatSettings.java
@@ -29,7 +29,7 @@ public class ChatSettings extends tag_formats {
 
 	/**
 	 * @param formatGroups
-	 *            the formatGroups to set
+	 *						the formatGroups to set
 	 */
 	public static void setFormatGroups(Map<String, channelFormats> formatGroups) {
 		ChatSettings.formatGroups = formatGroups;
@@ -79,7 +79,7 @@ public class ChatSettings extends tag_formats {
 
 	/**
 	 * @param d
-	 *            the spam_time to set
+	 *						the spam_time to set
 	 */
 	public static void setSpam_time(Double d) {
 		ChatSettings.spam_time = d;
@@ -94,7 +94,7 @@ public class ChatSettings extends tag_formats {
 
 	/**
 	 * @param modify_chat
-	 *            the modify_chat to set
+	 *						the modify_chat to set
 	 */
 	public static void setModify_chat(boolean modify_chat) {
 		ChatSettings.modify_chat = modify_chat;
@@ -109,7 +109,7 @@ public class ChatSettings extends tag_formats {
 
 	/**
 	 * @param per_world
-	 *            the per_world to set
+	 *						the per_world to set
 	 */
 	public static void setPer_world(boolean per_world) {
 		ChatSettings.per_world = per_world;
@@ -124,7 +124,7 @@ public class ChatSettings extends tag_formats {
 
 	/**
 	 * @param HeroicDeathToIRC
-	 *            the HeroicDeathToIRC to set
+	 *						the HeroicDeathToIRC to set
 	 */
 	public static void setHeroicDeathToIRC(boolean HeroicDeathToIRC) {
 		ChatSettings.heroicDeathToIRC = HeroicDeathToIRC;
@@ -139,7 +139,7 @@ public class ChatSettings extends tag_formats {
 
 	/**
 	 * @param heroicDeathTags
-	 *            the heroicDeathTags to set
+	 *						the heroicDeathTags to set
 	 */
 	public static void setheroicDeathTags(String heroicDeathTags) {
 		ChatSettings.heroicDeathTags = heroicDeathTags;

--- a/src/com/palmergames/bukkit/TownyChat/config/ConfigurationHandler.java
+++ b/src/com/palmergames/bukkit/TownyChat/config/ConfigurationHandler.java
@@ -251,6 +251,9 @@ public class ConfigurationHandler {
 						if (element.equalsIgnoreCase("nation"))
 							group.setNATION(subNodes.get(element).toString());
 
+						if (element.equalsIgnoreCase("coalition"))
+							group.setCOALITION(subNodes.get(element).toString());
+
 						if (element.equalsIgnoreCase("default"))
 							group.setDEFAULT(subNodes.get(element).toString());
 					}
@@ -276,6 +279,9 @@ public class ConfigurationHandler {
 	
 								if (element.equalsIgnoreCase("nation"))
 									group.setNATION(world.get(element).toString());
+
+								if (element.equalsIgnoreCase("coalition"))
+									group.setCOALITION(world.get(element).toString());
 	
 								if (element.equalsIgnoreCase("default"))
 									group.setDEFAULT(world.get(element).toString());
@@ -336,6 +342,7 @@ public class ConfigurationHandler {
 		String global = "{channelTag} {worldname}{townytagoverride}{townycolor}{permprefix}{group} {townyprefix}{modplayername}{townypostfix}{permsuffix}&f:{msgcolour} {msg}";
 		String town = "{channelTag} {townycolor}{permprefix}{townyprefix}{playername}{townypostfix}{permsuffix}&f:{msgcolour} {msg}";
 		String nation = "{channelTag}{towntagoverride}{townycolor}{permprefix}{townyprefix}{playername}{townypostfix}{permsuffix}&f:{msgcolour} {msg}";
+		String coalition = "{channelTag}{townytagoverride}{townycolor}{permprefix}{townyprefix}{playername}{townypostfix}{permsuffix}&f:{msgcolour} {msg}";
 		String default_ = "{channelTag} {permprefix}{playername}{permsuffix}&f:{msgcolour} {msg}";
 		
 		String tag_world = "&f[&f%s&f] ";
@@ -356,6 +363,7 @@ public class ConfigurationHandler {
 		newConfig = newConfig.replace("[globalformat]", (defaults)? global : ChatSettings.getFormatGroup("channel_formats").getGLOBAL());
 		newConfig = newConfig.replace("[townformat]", (defaults)? town : ChatSettings.getFormatGroup("channel_formats").getTOWN());
 		newConfig = newConfig.replace("[nationformat]", (defaults)? nation : ChatSettings.getFormatGroup("channel_formats").getNATION());
+		newConfig = newConfig.replace("[coalitionformat]", (defaults)? coalition : ChatSettings.getFormatGroup("channel_formats").getCOALITION());
 		newConfig = newConfig.replace("[defaultformat]", (defaults)? default_ : ChatSettings.getFormatGroup("channel_formats").getDEFAULT());
 
 		newConfig = newConfig.replace("[tag_world]", (defaults)? tag_world : ChatSettings.getWorldTag());
@@ -374,12 +382,13 @@ public class ConfigurationHandler {
 			if (!key.equalsIgnoreCase("channel_formats")) {
 				channelFormats world = ChatSettings.getFormatGroup(key);
 				
-				newConfig += "    '" + key + "':" + System.getProperty("line.separator");
+				newConfig += "		'" + key + "':" + System.getProperty("line.separator");
 				
-				newConfig += "      global: '" + ((defaults)? global : world.getGLOBAL()) + "'" + System.getProperty("line.separator");
-				newConfig += "      town: '" + ((defaults)? town : world.getTOWN()) + "'" + System.getProperty("line.separator");
-				newConfig += "      nation: '" + ((defaults)? nation : world.getNATION()) + "'" + System.getProperty("line.separator");
-				newConfig += "      default: '" + ((defaults)? default_ : world.getDEFAULT()) + "'" + System.getProperty("line.separator");
+				newConfig += "			global: '" + ((defaults)? global : world.getGLOBAL()) + "'" + System.getProperty("line.separator");
+				newConfig += "			town: '" + ((defaults)? town : world.getTOWN()) + "'" + System.getProperty("line.separator");
+				newConfig += "			nation: '" + ((defaults)? nation : world.getNATION()) + "'" + System.getProperty("line.separator");
+				newConfig += "			coalition: '" + ((defaults)? coalition : world.getCOALITION()) + "'" + System.getProperty("line.separator");
+				newConfig += "			default: '" + ((defaults)? default_ : world.getDEFAULT()) + "'" + System.getProperty("line.separator");
 			}
 			
 		}


### PR DESCRIPTION
I have added a new type of channel. It's called "coalition chat" (default command: /cc). When a player that belongs to a nation use this channel, the message can be read by players of nations allied with the sender's nation.
