### PR TITLE
Added dynmap to softdepend list

### DIFF
--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -6,7 +6,7 @@ website: http://code.google.com/a/eclipselabs.org/p/towny/
 description: >
     TownyChat plugin which hooks Towny.
 
-softdepend: [Towny, CraftIRC]
+softdepend: [Towny, CraftIRC, dynmap]
 
 ############################################################
 # +------------------------------------------------------+ #


### PR DESCRIPTION
fix for "[Server] WARN [TownyChat] Loaded class org.dynmap.DynmapAPI from dynmap v3.1-beta3a-409 which is not a depend, softdepend or loadbefore of this plugin."